### PR TITLE
changed user into player in routers

### DIFF
--- a/routers/auth.js
+++ b/routers/auth.js
@@ -2,7 +2,7 @@ const bcrypt = require("bcrypt");
 const { Router } = require("express");
 const { toJWT } = require("../auth/jwt");
 const authMiddleware = require("../auth/middleware");
-const User = require("../models/").user;
+const User = require("../models/").player;
 const { SALT_ROUNDS } = require("../config/constants");
 
 const router = new Router();
@@ -21,7 +21,7 @@ router.post("/login", async (req, res, next) => {
 
     if (!user || !bcrypt.compareSync(password, user.password)) {
       return res.status(400).send({
-        message: "User with that email not found or password incorrect"
+        message: "User with that email not found or password incorrect",
       });
     }
 
@@ -44,7 +44,7 @@ router.post("/signup", async (req, res) => {
     const newUser = await User.create({
       email,
       password: bcrypt.hashSync(password, SALT_ROUNDS),
-      name
+      name,
     });
 
     delete newUser.dataValues["password"]; // don't send back the password hash


### PR DESCRIPTION
changed
`const User = require("../models/").user;`
into
`const User = require("../models/").player;`
in routers/auth.js 

model.player holds - among others - the same properties as model.user, so all auth routes still work fine.
This messy use of const names will be cleaned up later, as models.user might be needed for additional features.